### PR TITLE
[Feat] Zustand 스토어 연결

### DIFF
--- a/developer-test-template/src/api/services/index.js
+++ b/developer-test-template/src/api/services/index.js
@@ -5,9 +5,8 @@ export const getQuestions = async () => {
   const { data } = await api.get('/api/questions');
   return data;
 };
-
-// 특정 질문 조회
-export const getQuestionById = async (id) => {
-  const { data } = await api.get(`/api/questions/${id}`);
+// 결과 조회
+export const getResults = async (type) => {
+  const { data } = await api.get(`/api/results/${type}`);
   return data;
 };

--- a/developer-test-template/src/assets/results/index.js
+++ b/developer-test-template/src/assets/results/index.js
@@ -1,0 +1,19 @@
+import frontend from '../frontend.webp';
+import ai from '../ai.webp';
+import backend from '../backend.webp';
+import data from '../data.webp';
+import devops from '../devops.webp';
+import fullstack from '../fullstack.webp';
+import gamedev from '../gamedev.webp';
+import mobile from '../mobile.webp';
+
+export const resultImages = {
+  frontend,
+  ai,
+  backend,
+  data,
+  devops,
+  fullstack,
+  gamedev,
+  mobile,
+};

--- a/developer-test-template/src/components/common/Card.jsx
+++ b/developer-test-template/src/components/common/Card.jsx
@@ -1,7 +1,7 @@
 export default function Card({ children, className = '' }) {
   return (
     <div
-      className={`mx-auto w-full rounded-2xl bg-white p-6 shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] ${className}`}
+      className={`mx-auto flex min-h-[524px] w-full max-w-[448px] flex-col items-center justify-center rounded-2xl bg-white p-6 shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] ${className}`}
     >
       {children}
     </div>

--- a/developer-test-template/src/hooks/queries/useQuestions.js
+++ b/developer-test-template/src/hooks/queries/useQuestions.js
@@ -1,28 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getQuestions } from '../../api/services';
-// import { getQuestionById } from '../../api/services';
-
-// export const useQuestions = (id) =>
-//   useQuery({
-//     queryKey: ['question', id],
-//     queryFn: () => getQuestionById(id),
-//     enabled: !!id, // id 있을 때만 호출
-//     staleTime: 1000 * 60,
-//   });
-
-// 랜덤 숫자 5개 뽑기
-const pick5 = (arr) => {
-  const copy = [...arr];
-  for (let i = copy.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [copy[i], copy[j]] = [copy[j], copy[i]];
-  }
-  return copy.slice(0, 5);
-};
+import { pick5 } from '../../utils/pick5';
 
 export const useQuestions = () =>
   useQuery({
     queryKey: ['questions'],
     queryFn: getQuestions,
-    select: (data) => pick5(data), //  여기서 랜덤 5개로 변환
+    select: (data) => pick5(data),
   });

--- a/developer-test-template/src/hooks/queries/useResult.js
+++ b/developer-test-template/src/hooks/queries/useResult.js
@@ -1,9 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import { getResult } from '../api/result';
+import { getResults } from '../../api/services';
 
-export const useResult = () =>
+export const useResults = (type) =>
   useQuery({
-    queryKey: ['result'],
-    queryFn: getResult,
+    queryKey: ['result', type],
+    queryFn: () => getResults(type),
     staleTime: 1000 * 60,
+    enabled: !!type,
+    select: (data) => data?.result ?? data,
   });

--- a/developer-test-template/src/pages/QuestionPage.jsx
+++ b/developer-test-template/src/pages/QuestionPage.jsx
@@ -1,36 +1,63 @@
-import { useState } from 'react';
 import Card from '../components/common/Card';
 import ProgressBar from '../components/common/progressbar';
 import Button from '../components/common/Button';
+import hamster from '../assets/Icon.webp';
 import { useQuestions } from '../hooks/queries/useQuestions';
-import hamster from '../assets/hamster.png';
+import { useAnswerStore } from '../store';
+import { useNavigate } from 'react-router-dom';
+import { pickMostType } from '../utils/pickMostType';
 
 function QuestionPage() {
+  const navigate = useNavigate();
   const { data: picked, isLoading, isError, error } = useQuestions();
-  const [step, setStep] = useState(0);
+
+  const step = useAnswerStore((s) => s.step);
+  const setStep = useAnswerStore((s) => s.setStep);
+  const answers = useAnswerStore((s) => s.answers);
+  const setAnswer = useAnswerStore((s) => s.setAnswer);
+  const setResultType = useAnswerStore((s) => s.setResultType);
+
+  const total = 5;
 
   if (isLoading) return <Card>로딩중...</Card>;
   if (isError) return <Card>에러: {error?.message ?? '요청 실패'}</Card>;
   if (!picked?.length) return <Card>질문 없음</Card>;
 
-  const question = picked[step];
+  const safeStep = Math.min(step, Math.min(total - 1, picked.length - 1));
+  const question = picked[safeStep];
+  const isLast = safeStep === total - 1;
+
+  if (!question) return <Card>질문 데이터 오류</Card>;
 
   return (
-    <Card className="flex min-h-[524px] w-full max-w-[448px] flex-col items-center justify-center">
-      <ProgressBar current={step + 1} total={5} />
+    <Card className="">
+      <ProgressBar current={safeStep + 1} total={total} />
 
       <img className="h-30 w-30" src={hamster} alt="" />
-
-      <h1 className="mt-6 text-lg font-semibold">Q{step + 1}</h1>
+      <h1 className="mt-6 text-lg font-semibold">Q{safeStep + 1}</h1>
       <h2 className="mt-6 text-lg">{question.text}</h2>
 
       <div className="mt-6 flex flex-col gap-3">
         {question.options.map((opt, idx) => (
           <Button
             key={idx}
-            type="button"
             className="bg-background text-body"
-            onClick={() => setStep((prev) => Math.min(4, prev + 1))}
+            onClick={() => {
+              const key = `q${safeStep + 1}`;
+              const type = opt.type;
+
+              const nextAnswers = { ...answers, [key]: type };
+              setAnswer(key, type);
+
+              if (isLast) {
+                const types = Object.values(nextAnswers);
+                setResultType(pickMostType(types, type));
+                navigate('/result');
+                return;
+              }
+
+              setStep((prev) => Math.min(total - 1, prev + 1));
+            }}
           >
             {opt.text}
           </Button>

--- a/developer-test-template/src/pages/ResultPage.jsx
+++ b/developer-test-template/src/pages/ResultPage.jsx
@@ -1,10 +1,45 @@
+import { resultImages } from '../assets/results';
+import Badge from '../components/common/Badge';
+import Button from '../components/common/Button';
 import Card from '../components/common/Card';
+import { useResults } from '../hooks/queries/useResult';
+import { useAnswerStore } from '../store';
 
 function ResultPage() {
+  const type = useAnswerStore((s) => s.resultType);
+  const { data, isLoading, isError, error } = useResults(type);
+
+  if (!type) return <Card>결과 타입이 없어요 (질문부터 진행해줘)</Card>;
+  if (isLoading) return <Card>로딩중...</Card>;
+  if (isError) return <Card>에러: {error?.message ?? '요청 실패'}</Card>;
+  if (!data) return <Card>결과 없음</Card>;
+
+  const imgSrc = resultImages[data.type];
+  console.log(imgSrc);
+
   return (
     <Card className="min-h-[524px] w-full max-w-[448px]">
-      결과 페이지 입니다
-      <p>나는 어떤 개발자</p>
+      <header>
+        <p className="">당신의 개발자 유형</p>
+        <h1 className="">{data.name}</h1>
+      </header>
+
+      {imgSrc && (
+        <img src={imgSrc} alt={data.name} className="mt-4 h-32 w-32" />
+      )}
+      <section>
+        <h2> {data.title} </h2>
+        <p>{data.description}</p>
+        <Badge></Badge>
+      </section>
+      <section>{data.characteristics}</section>
+      <nav>
+        <Button>결과 공유하기</Button>
+        <Button>다시 테스트하기</Button>
+      </nav>
+      <footer>
+        <small>made with ❤ ozcoding</small>
+      </footer>
     </Card>
   );
 }

--- a/developer-test-template/src/store/index.js
+++ b/developer-test-template/src/store/index.js
@@ -1,1 +1,25 @@
-// 각 문제에 대한 답변을 전역 상태로 관리하세요.
+import { create } from 'zustand';
+
+const initialState = {
+  step: 0,
+  answers: {},
+  resultType: null,
+};
+
+export const useAnswerStore = create((set) => ({
+  ...initialState,
+
+  setStep: (updater) =>
+    set((state) => ({
+      step: typeof updater === 'function' ? updater(state.step) : updater,
+    })),
+
+  setAnswer: (key, value) =>
+    set((state) => ({
+      answers: { ...state.answers, [key]: value },
+    })),
+
+  setResultType: (type) => set({ resultType: type }),
+
+  reset: () => set(initialState),
+}));

--- a/developer-test-template/src/utils/pick5.js
+++ b/developer-test-template/src/utils/pick5.js
@@ -1,0 +1,8 @@
+export const pick5 = (arr) => {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy.slice(0, 5);
+};

--- a/developer-test-template/src/utils/pickMostType.js
+++ b/developer-test-template/src/utils/pickMostType.js
@@ -1,0 +1,22 @@
+// 타입들 모두 배열에 넣고 카운트가 제일 높은것 추출
+export function pickMostType(types = [], fallbackType = null) {
+  const counts = {};
+
+  for (const t of types) {
+    if (!t) continue;
+    counts[t] = (counts[t] || 0) + 1;
+  }
+
+  let bestType = fallbackType;
+  let bestCount = -1;
+
+  for (const [type, count] of Object.entries(counts)) {
+    // 동점시 마지막 선택
+    if (count > bestCount || (count === bestCount && type === fallbackType)) {
+      bestType = type;
+      bestCount = count;
+    }
+  }
+
+  return bestType;
+}


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

- closes #29 

## ✨ 변경 내용
- zustand 스토어로 step/answers/resultType 전역 상태 관리 연결

- 마지막 질문 선택 시 답변 type 최다득표 계산 후 결과 페이지로 이동하도록 플로우 구현

- resultType 기반 결과 조회 API 연동 및 React Query 설정(queryKey/type 전달, enabled) 수정

- 결과 타입별 이미지(src/assets/results) 매핑 적용
<!-- 변경한 내용을 간략하게 설명해주세요. -->

## 📸 스크린샷(선택)
<img width="578" height="634" alt="스크린샷 2026-03-04 000202" src="https://github.com/user-attachments/assets/94c39872-9807-4fa7-a30f-d6886aea9097" />
<img width="553" height="636" alt="스크린샷 2026-03-04 000757" src="https://github.com/user-attachments/assets/17ddc810-4637-421e-a159-bb2b0c96477e" />

<!-- 스크린샷이 있다면 첨부해주세요. -->

## 📚 참고사항

<!-- 참고할 사항이 있다면 적어주세요. -->
